### PR TITLE
Version 1.1.0

### DIFF
--- a/Sources/StyleableUI/StyleableView.swift
+++ b/Sources/StyleableUI/StyleableView.swift
@@ -85,21 +85,15 @@ public extension Array where Element == UIView {
 
 // MARK: - Predefined styles
 
-public typealias SView = Styles.UIView
-public typealias SButton = Styles.UIButton
-public typealias SLabel = Styles.UILabel
-public typealias STextField = Styles.UITextField
-public typealias STextView = Styles.UITextView
-
-public struct Styles {
+public struct S {
     
-    public struct UIView { }
+    public struct View { }
     
-    public struct UIButton { }
+    public struct Button { }
     
-    public struct UILabel { }
+    public struct Label { }
     
-    public struct UITextField { }
+    public struct TextField { }
     
-    public struct UITextView { }
+    public struct TextView { }
 }

--- a/Sources/StyleableUI/StyleableView.swift
+++ b/Sources/StyleableUI/StyleableView.swift
@@ -83,7 +83,7 @@ public extension Array where Element == UIView {
     }
 }
 
-// MARK: - Predifined styles
+// MARK: - Predefined styles
 
 public typealias SView = Styles.UIView
 public typealias SButton = Styles.UIButton

--- a/Sources/StyleableUI/StyleableView.swift
+++ b/Sources/StyleableUI/StyleableView.swift
@@ -11,36 +11,95 @@ public protocol StyleableView { }
 
 extension UIView: StyleableView { }
 
-public typealias Style<T> = (T) -> Void
+// MARK: - Typealiases
 
+public typealias Style<T> = (T) -> Void
+public typealias StyleGet<T, V> = (T) -> V
+
+// MARK: - Apply
+
+// Applying style without return
 public extension StyleableView {
     
-    // Applying style
     func apply(style: Style<Self>) {
         style(self)
     }
     
     func apply(styles: Style<Self>...) {
-        styles.forEach(apply(style:))
+        styles.forEach { apply(style: $0) }
     }
     
     func apply(styles: [Style<Self>]) {
-        styles.forEach(apply(style:))
+        styles.forEach { apply(style: $0) }
     }
+}
+
+// MARK: - Style
+
+// Applying style and return self
+public extension StyleableView {
     
-    // Applying style and returning self
-    func with(_ style: Style<Self>) -> Self {
+    func style(_ style: Style<Self>) -> Self {
         apply(style: style)
         return self
     }
     
-    func styled(using styles: Style<Self>...) -> Self {
+    func style(using styles: Style<Self>...) -> Self {
         apply(styles: styles)
         return self
     }
     
-    func styled(using styles: [Style<Self>]) -> Self {
+    func style(using styles: [Style<Self>]) -> Self {
         apply(styles: styles)
         return self
     }
+}
+
+// MARK: - StyleGet
+
+// Applying style and return applyed propertie
+public extension StyleableView {
+    
+    @discardableResult
+    func apply<V>(style: StyleGet<Self, V>) -> V {
+        return style(self)
+    }
+}
+
+// MARK: - StyleableView + Array
+
+public extension Array where Element == UIView {
+    
+    func apply(style: Style<Element>) {
+        forEach { $0.apply(style: style) }
+    }
+    
+    func apply(styles: Style<Element>...) {
+        forEach { $0.apply(styles: styles) }
+    }
+    
+    func apply(styles: [Style<Element>]) {
+        forEach { $0.apply(styles: styles) }
+    }
+}
+
+// MARK: - Predifined styles
+
+public typealias SView = Styles.UIView
+public typealias SButton = Styles.UIButton
+public typealias SLabel = Styles.UILabel
+public typealias STextField = Styles.UITextField
+public typealias STextView = Styles.UITextView
+
+public struct Styles {
+    
+    public struct UIView { }
+    
+    public struct UIButton { }
+    
+    public struct UILabel { }
+    
+    public struct UITextField { }
+    
+    public struct UITextView { }
 }


### PR DESCRIPTION
- Add new way to apply style and return applied property like CALayer. This style called StyleGet.

Example:
``` swift
final class StyledView: UIView {
    
    var gradient: CAGradientLayer?
    
    override func awakeFromNib() {
        super.awakeFromNib()
        
        gradient = apply(style: SView.Base.gradient)
    }
    
    override func layoutSubviews() {
        super.layoutSubviews()
        
        gradient?.frame = bounds
    }
}
```

``` swift
extension SView {
    
    struct Base {
        
        static var gradient: StyleGet<UIView, CAGradientLayer> = { view in
            
            let gradient = CAGradientLayer()
            gradient.type = .axial
            gradient.startPoint = CGPoint(x: 0, y: 1)
            gradient.endPoint = CGPoint(x: 1, y: 0)
            gradient.locations = [0, 1]
            
            gradient.colors = [
                UIColor.blue.cgColor,
                UIColor.green.cgColor
            ]
            
            gradient.frame = view.bounds
            view.layer.insertSublayer(gradient, at: 0)
            return gradient
        }
    }
}
```

- Add predefined style structs with type aliases: SView, SButton, SLabel, STextField, STextView. This can reduce length of style.
- Add extension for array to apply styles to whole array.
- Separate framework parts to extensions.